### PR TITLE
Bump Bitnami Redis chart version

### DIFF
--- a/charts/postcoder-proxy/Chart.yaml
+++ b/charts/postcoder-proxy/Chart.yaml
@@ -25,7 +25,7 @@ appVersion: "v3.0.0"
 
 dependencies:
   - name: "redis"
-    version: "16.10.0"
+    version: "16.13.2"
     repository: "https://charts.bitnami.com/bitnami"
     condition: redis.enabled
     alias: redis


### PR DESCRIPTION
The chart testing workflow action found an issue with the postcode-proxy chart. It relies on the Bitnami Redis chart pinned at `16.10.0`, however this is no longer available in the repository. The most recent chart version that also has the same app version is `16.13.2`.