### PR TITLE
bump the postcoder version

### DIFF
--- a/charts/postcoder-proxy/Chart.yaml
+++ b/charts/postcoder-proxy/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.0.0"
+appVersion: "v4.0.3"
 
 dependencies:
   - name: "redis"


### PR DESCRIPTION
Postcoder changes (v4.0.0 to v4.0.3)

- arm64 compatible image
- Removed the deprecated /pcw/:api_key... endpoint
- Timeout on the redis connection is reduced to 0.3s, which should stop the status method timing out during liveness checks
