### PR TITLE
bump image resizer version

### DIFF
--- a/charts/image-resizer/Chart.yaml
+++ b/charts/image-resizer/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5
+version: 0.2.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v4.0.2"
+appVersion: "v2.1.0"
 
 home: https://github.com/citizensadvice/helm-charts
 maintainers:


### PR DESCRIPTION
Not sure what happened here as there was never a v4.0.2.  Might be a mistake with a postcoder update.