### PR TITLE
Mokta version 3.0.2

### DIFF
--- a/charts/mokta/Chart.yaml
+++ b/charts/mokta/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mokta
 description: Standalone implementation of Mokta 3 for use with review apps - https://github.com/citizensadvice/mokta
 type: application
-version: 0.3.8
-appVersion: 3.0.1
+version: 0.3.9
+appVersion: 3.0.2
 home: https://github.com/citizensadvice/helm-charts
 maintainers:
   - email: ca-devops@citizensadvice.org.uk

--- a/charts/mokta/values.yaml
+++ b/charts/mokta/values.yaml
@@ -1,6 +1,5 @@
 image:
-  repository: public.ecr.aws/citizensadvice/mokta
-  tag: 3.0.0.pre3
+  repository: 979633842206.dkr.ecr.eu-west-1.amazonaws.com/mokta
 
 env:
   SAFE_HOSTS: https://*.qa.citizensadvice.org.uk


### PR DESCRIPTION
This updates to mokta 3.0.2

No significant changes, but it has a gem update for a rack security alert.

Due to a slightly oversight by myself, we weren't actually using the correct production version and were still on an rc version.