### PR TITLE
updates image resizer to 2.4.0

### DIFF
--- a/charts/image-resizer/Chart.yaml
+++ b/charts/image-resizer/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2.2.0"
+appVersion: "2.4.0"
 
 home: https://github.com/citizensadvice/helm-charts
 maintainers:

--- a/charts/image-resizer/values.yaml
+++ b/charts/image-resizer/values.yaml
@@ -15,7 +15,7 @@ externalSecrets: &external_secrets_config
 env: {}
 
 image:
-  repository: 979633842206.dkr.ecr.eu-west-1.amazonaws.com/image-resizer
+  repository: public.ecr.aws/citizensadvice/image-resizer
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/image-resizer/values.yaml
+++ b/charts/image-resizer/values.yaml
@@ -15,7 +15,7 @@ externalSecrets: &external_secrets_config
 env: {}
 
 image:
-  repository: public.ecr.aws/citizensadvice/image-resizer
+  repository: 979633842206.dkr.ecr.eu-west-1.amazonaws.com/image-resizer
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
Updates image resizer to [2.4.0.](https://github.com/citizensadvice/image-resizer/pull/36)

~This now uses the private ECR~